### PR TITLE
Throw exception if no gallery tiles found.

### DIFF
--- a/Application/MosaicStepFunctions/DetermineBestImagesFunction/Function.fs
+++ b/Application/MosaicStepFunctions/DetermineBestImagesFunction/Function.fs
@@ -74,7 +74,8 @@ let LoadGalleryItems (tableName: string) (galleryId: string) (_: ILambdaContext)
     }
 
     do! executeQuery()
-    return tileInfos
+    return if tileInfos.Count > 0 then tileInfos
+        else failwith (sprintf "GalleryItems is empty for the given Gallery: %s" galleryId)
 }
 
 


### PR DESCRIPTION
(My experience with F# is limited. Apologies if this is not idiomatic.)

Within MosaicStepFunctions, in the DetermineBestImages step, a list of available tiles is needed. The LoadGalleryItems function uses a table name and a gallery name to return a list of tiles available for mosaic construction. Previously, an empty list of tiles could be returned from this function. Because it is not useful to return an empty list from LoadGalleryItems, the function now throws an exception if no tiles are found.

The primary motivator for this change is better error messages and faster debugging. If an empty list of tiles is used an IndexOutOfRangeException will occur later in the program.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
